### PR TITLE
Handle duplicate ids when doing full copy

### DIFF
--- a/bender.js
+++ b/bender.js
@@ -49,6 +49,7 @@ var config = {
             paths: [
                 'smoke/**',
                 'ids/**',
+                'paste_events/**',
                 '!**/_*/**',
 
             ],

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -43,6 +43,8 @@
 
       editor.on('selectionChange', addIdIfNewHeading);
 
+      editor.on('paste', checkPastedContentForHeadings);
+
       function start() {
         editor.getCommand('autoid').setState(CKEDITOR.TRISTATE_ON);
         commandIsActive = true;

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -109,6 +109,7 @@
         var pastedContent = ev.data.dataValue,
           pastedContentAsHtml = CKEDITOR.htmlParser.fragment.fromHtml(pastedContent),
           pastedElements = pastedContentAsHtml.children,
+          writer = new CKEDITOR.htmlParser.basicWriter(),
           i, element, id, originalHeading;
 
         for (i = 0; i < pastedElements.length; i++) {
@@ -119,6 +120,9 @@
             element = resolveDuplicateIds(element, originalHeading);
           }
         }
+        
+        pastedContentAsHtml.writeHtml(writer);
+        ev.data.dataValue = writer.getHtml();
       }
 
       function checkForDuplicateId(id) {

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -59,7 +59,7 @@
 
       function addAllIds() {
         var headings = findAllHeadings(),
-        i, heading;
+          i, heading;
 
         for (i = 0; i < headings.count(); i++) {
           heading = headings.getItem(i);

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -133,6 +133,7 @@
         // id and the new heading should get a new one.
         if (newHeadingText === originalHeadingText) {
           newHeading.attributes.id = CKEDITOR.tools.getUniqueId();
+          editor.fire(EVENT_NAMES.ID_ADDED);
           return newHeading;
         }
 

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -75,6 +75,19 @@
         return editor.document.find('h1, h2, h3, h4, h5, h6');
       }
 
+      function findHeadingIds(headings) {
+        var ids = [],
+          i, heading, id;
+
+        for (i = 0; i < headings.count(); i++) {
+          heading = headings.getItem(i);
+          if (id = heading.getAttribute('id')) {
+            ids.push(id)
+          }
+        }
+        return ids;
+      }
+
       function addId(heading) {
         var uuid = CKEDITOR.tools.getUniqueId();
         heading.setAttributes({ id: uuid });

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -133,6 +133,19 @@
         }
       }
 
+      function resolveDuplicateIds(newHeading, originalHeading) {
+        var newHeadingText = newHeading.children[0].value,
+          originalHeadingText = originalHeading.getText();
+
+        // if the text is identical (full copy), the original should retain its
+        // id and the new heading should get a new one.
+        if (newHeadingText === originalHeadingText) {
+          newHeading.attributes.id = CKEDITOR.tools.getUniqueId();
+          return newHeading;
+        }
+
+      }
+
     }
   });
 })();

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -121,6 +121,18 @@
         }
       }
 
+      function checkForDuplicateId(id) {
+        var headingIds = findHeadingIds(findAllHeadings()),
+          i, headingId, originalHeading;
+
+        for (i = 0; i < headingIds.length; i++) {
+          headingId = headingIds[i];
+          if (id === headingId) {
+            return originalHeading = editor.document.getById(headingId);
+          }
+        }
+      }
+
     }
   });
 })();

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -3,7 +3,8 @@
 (function () {
   var EVENT_NAMES = {
     ALL_IDS_COMPLETE: 'allIdsComplete',
-    ID_ADDED: 'idAdded'
+    ID_ADDED: 'idAdded',
+    ID_RETAINED: 'idRetained'
   };
 
   CKEDITOR.plugins.add('autoid', {
@@ -128,6 +129,15 @@
       function resolveDuplicateIds(newHeading, originalHeading) {
         var newHeadingText = newHeading.children[0].value,
           originalHeadingText = originalHeading.getText();
+
+        // if the original heading has no content (blank or just a line-feed
+        // character is left when all the content is cut), the original heading
+        // will be removed and the new heading will retain the id
+        if ( !originalHeadingText || (originalHeadingText.length === 1 && originalHeadingText.charCodeAt(0) === 10)) {
+          originalHeading.remove();
+          editor.fire(EVENT_NAMES.ID_RETAINED);
+          return newHeading;
+        }
 
         // if the text is identical (full copy), the original should retain its
         // id and the new heading should get a new one.

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -105,6 +105,22 @@
         return element.is('h1', 'h2', 'h3', 'h4', 'h5', 'h6');
       }
 
+      function checkPastedContentForHeadings(ev) {
+        var pastedContent = ev.data.dataValue,
+          pastedContentAsHtml = CKEDITOR.htmlParser.fragment.fromHtml(pastedContent),
+          pastedElements = pastedContentAsHtml.children,
+          i, element, id, originalHeading;
+
+        for (i = 0; i < pastedElements.length; i++) {
+          element = pastedElements[i];
+          id = element.attributes.id;
+          originalHeading = checkForDuplicateId(id);
+          if (originalHeading) {
+            element = resolveDuplicateIds(element, originalHeading);
+          }
+        }
+      }
+
     }
   });
 })();

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -133,7 +133,7 @@
         // if the original heading has no content (blank or just a line-feed
         // character is left when all the content is cut), the original heading
         // will be removed and the new heading will retain the id
-        if ( !originalHeadingText || (originalHeadingText.length === 1 && originalHeadingText.charCodeAt(0) === 10)) {
+        if ( originalHeadingText.length <= 1 && notWordCharacter(originalHeadingText.charAt(0))) {
           originalHeading.remove();
           editor.fire(EVENT_NAMES.ID_RETAINED);
           return newHeading;
@@ -147,6 +147,13 @@
           return newHeading;
         }
 
+      }
+
+      function notWordCharacter(character) {
+        if (!character)
+          return true;
+
+        return !(/\w/.test(character));
       }
 
     }

--- a/tests/paste_events/_helpers/pasting.js
+++ b/tests/paste_events/_helpers/pasting.js
@@ -1,0 +1,72 @@
+/* exported assertPasteEvent, pasteFiles */
+
+'use strict';
+
+function assertPasteEvent( editor, eventData, expected, message, async ) {
+	var priority = 999,
+		executed = false;
+
+	message = message ? message + ' - ' : '';
+
+	// Listener's priority can be specified.
+	if ( 'priority' in expected ) {
+		priority = expected.priority;
+		delete expected.priority;
+	}
+
+	// Type doesn't have to be specified.
+	if ( !eventData.type )
+		eventData.type = 'auto';
+
+	eventData.method = 'paste';
+	// Allow passing a dataTransfer mock.
+	if ( !eventData.dataTransfer ) {
+		eventData.dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer();
+	}
+
+	editor.once( 'paste', onPaste, null, null, priority );
+	editor.fire( 'paste', eventData );
+
+	if ( async )
+		wait();
+	else
+		assert.isTrue( executed, message + 'paste listener was executed' );
+
+	function assertPaste( data ) {
+		if ( typeof expected == 'function' )
+			expected( data, message );
+		else {
+			// Compare all expected values.
+			for ( var name in expected )
+				assert.areSame( expected[ name ], data[ name ], message + 'data.' + name );
+		}
+	}
+
+	function onPaste( evt ) {
+		var data = evt.data;
+		evt.removeListener();
+		evt.cancel(); // Cancel for performance reason - we don't need insertion happen.
+
+		executed = true;
+
+		if ( async )
+			resume( function() {
+				assertPaste( data );
+			} );
+		else
+			assertPaste( data );
+	}
+}
+
+function pasteFiles( editor, files, dataValue ) {
+	var	nativeData = bender.tools.mockNativeDataTransfer();
+
+	nativeData.files = files;
+
+	var dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData );
+
+	editor.fire( 'paste', {
+		dataTransfer: dataTransfer,
+		dataValue: dataValue ? dataValue : ''
+	} );
+}

--- a/tests/paste_events/_helpers/pasting.js
+++ b/tests/paste_events/_helpers/pasting.js
@@ -1,5 +1,8 @@
 /* exported assertPasteEvent, pasteFiles */
 
+// pasting.js from Clipboard plugin
+// https://github.com/ckeditor/ckeditor-dev/blob/master/tests/plugins/clipboard/_helpers/pasting.js
+
 'use strict';
 
 function assertPasteEvent( editor, eventData, expected, message, async ) {

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -39,6 +39,8 @@
         shiftKey: false
       }));
 
+      console.log(editor.getData());
+
       resumeAfter(editor, 'allIdsComplete', function() {
         heading = editor.editable().findOne('h1');
 
@@ -135,8 +137,9 @@
 
           // verify only one heading on page (original was deleted)
           assert.areSame(headings.count(), 1);
-          // verify the pasted heading retains original id
+          // verify the pasted heading retains original id and pasted content
           assert.areSame('12345', heading.getAttribute('id'));
+          assert.areSame('Pasted Heading', heading.getText());
         });
 
         editor.execCommand('paste', secondHeading);

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -32,14 +32,34 @@
 
       bot.setHtmlWithSelection(headingWithId);
 
+      // hit enter key to prevent pasting text in same heading element
+      editor.editable().fire('keydown', new CKEDITOR.dom.event({
+        keyCode: 13,
+        ctrlKey: false,
+        shiftKey: false
+      }));
+
+      resumeAfter(editor, 'allIdsComplete', function() {
+        heading = editor.editable().findOne('h1');
+
+        // verify original heading still has same id
+        assert.areSame('12345', heading.getAttribute('id'));
+
+        editor.execCommand('paste', headingWithDifferentId);
+
+        headings = editor.editable().find('h1');
+
+        // get pasted heading (second heading on page)
+        heading = headings.getItem(1);
+
+        // verify pasted heading still has the original id
+        assert.areSame('678910', heading.getAttribute('id'));
+      });
+
       editor.execCommand('autoid');
 
-      editor.execCommand('paste', headingWithDifferentId);
-
-      headings = editor.editable().find('h1');
-      heading = headings.getItem(1);
-
-      assert.areSame('678910', heading.getAttribute('id'));
+      // wait for initial id assignment for all headings to complete
+      wait();
     },
 
     'test pasted heading gets new id when it is a full copy of an existing heading': function() {
@@ -55,10 +75,10 @@
 
       // hit enter key to prevent pasting text in same heading element
       editor.editable().fire('keydown', new CKEDITOR.dom.event({
-						keyCode: 13,
-						ctrlKey: false,
-						shiftKey: false
-					}));
+        keyCode: 13,
+        ctrlKey: false,
+        shiftKey: false
+      }));
 
       resumeAfter(editor, 'allIdsComplete', function() {
         heading = editor.editable().findOne('h1');

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -21,40 +21,69 @@
       this.editor.execCommand('autoid');
     },
 
-    'test copied header will have a new id when a full copy is made': function() {
+    'test pasted heading id does not change when it is not a duplicate id': function() {
       var bot = this.editorBot,
         editor = bot.editor,
         heading,
         headings,
         resumeAfter = bender.tools.resumeAfter,
-        headingWithId = '<h1 id="12345">This is a heading^</h1>';
+        headingWithId = '<h1 id="12345">This is a heading^</h1>',
+        headingWithDifferentId = '<h1 id="678910">This is also a heading</h1>';
 
       bot.setHtmlWithSelection(headingWithId);
+
+      editor.execCommand('autoid');
+
+      editor.execCommand('paste', headingWithDifferentId);
+
+      headings = editor.editable().find('h1');
+      heading = headings.getItem(1);
+
+      assert.areSame('678910', heading.getAttribute('id'));
+    },
+
+    'test pasted heading gets new id when it is a full copy of an existing heading': function() {
+      var bot = this.editorBot,
+        editor = bot.editor,
+        heading,
+        headings,
+        resumeAfter = bender.tools.resumeAfter,
+        headingWithId = '<h1 id="12345">This is a heading^</h1>',
+        identicalHeading = '<h1 id="12345">This is a heading</h1>';
+
+      bot.setHtmlWithSelection(headingWithId);
+
+      // hit enter key to prevent pasting text in same heading element
+      editor.editable().fire('keydown', new CKEDITOR.dom.event({
+						keyCode: 13,
+						ctrlKey: false,
+						shiftKey: false
+					}));
 
       resumeAfter(editor, 'allIdsComplete', function() {
         heading = editor.editable().findOne('h1');
 
         // verify original heading still has same id
         assert.areSame('12345', heading.getAttribute('id'));
+
+        resumeAfter(editor, 'idAdded', function() {
+          headings = editor.editable().find('h1');
+          // get pasted heading (second heading on page)
+          heading = headings.getItem(1);
+
+          // verify pasted heading does not have the original id
+          assert.areNotSame('12345', heading.getAttribute('id'));
+        });
+
+        editor.execCommand('paste', identicalHeading);
+
+        // paste identical heading, wait for new id to be added to the new copy
+        wait();
       });
 
       editor.execCommand('autoid');
 
       // wait for initial id assignment for all headings to complete
-      wait();
-
-      resumeAfter(editor, 'idAdded', function() {
-        headings = editor.editable().find('h1');
-        // get pasted heading (second heading on page)
-        heading = headings.getItem(1);
-
-        // verify pasted heading does not have the original id
-        assert.areNotSame('12345', heading.getAttribute('id'));
-      });
-
-      editor.execCommand('paste', headingWithId);
-
-      // paste identical heading, wait for new id to be added to the new copy
       wait();
     }
 

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -1,0 +1,22 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: clipboard,autoid */
+/* bender-include: _helpers/pasting.js */
+/* global assertPasteEvent */
+
+'use strict';
+
+(function() {
+  bender.editor = {
+    config: {
+      enterMode: CKEDITOR.ENTER_P,
+      autoid: {
+        autostart: false
+      }
+    }
+  };
+
+  bender.test({
+
+  });
+
+})();

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -17,6 +17,47 @@
 
   bender.test({
 
+    tearDown: function() {
+      this.editor.execCommand('autoid');
+    },
+
+    'test copied header will have a new id when a full copy is made': function() {
+      var bot = this.editorBot,
+        editor = bot.editor,
+        heading,
+        headings,
+        resumeAfter = bender.tools.resumeAfter,
+        headingWithId = '<h1 id="12345">This is a heading^</h1>';
+
+      bot.setHtmlWithSelection(headingWithId);
+
+      resumeAfter(editor, 'allIdsComplete', function() {
+        heading = editor.editable().findOne('h1');
+
+        // verify original heading still has same id
+        assert.areSame('12345', heading.getAttribute('id'));
+      });
+
+      editor.execCommand('autoid');
+
+      // wait for initial id assignment for all headings to complete
+      wait();
+
+      resumeAfter(editor, 'idAdded', function() {
+        headings = editor.editable().find('h1');
+        // get pasted heading (second heading on page)
+        heading = headings.getItem(1);
+
+        // verify pasted heading does not have the original id
+        assert.areNotSame('12345', heading.getAttribute('id'));
+      });
+
+      editor.execCommand('paste', headingWithId);
+
+      // paste identical heading, wait for new id to be added to the new copy
+      wait();
+    }
+
   });
 
 })();

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -105,6 +105,48 @@
 
       // wait for initial id assignment for all headings to complete
       wait();
+    },
+
+    'test full cut and paste removes blank heading and original id retained': function() {
+      var bot = this.editorBot,
+        editor = bot.editor,
+        heading,
+        headings,
+        resumeAfter = bender.tools.resumeAfter;
+
+      // when the full content of a heading is cut, the element tag is left
+      var startHtml = '<h1 id="12345"></h1>',
+        secondHeading = '<h1 id="12345">Pasted Heading</h1>';
+
+      bot.setHtmlWithSelection(startHtml);
+
+      editor.editable().fire('keydown', new CKEDITOR.dom.event({
+        keyCode: 13,
+        ctrlKey: false,
+        shiftKey: false
+      }));
+
+      resumeAfter(editor, 'allIdsComplete', function() {
+
+        resumeAfter(editor, 'idRetained', function() {
+          headings = editor.editable().find('h1');
+
+          heading = headings.getItem(0);
+
+          // verify only one heading on page (original was deleted)
+          assert.areSame(headings.count(), 1);
+          // verify the pasted heading retains original id
+          assert.areSame('12345', heading.getAttribute('id'));
+        });
+
+        editor.execCommand('paste', secondHeading);
+
+        wait();
+      });
+
+      editor.execCommand('autoid');
+
+      wait();
     }
 
   });


### PR DESCRIPTION
This adds handling of a variety of heading-id integrity issues that can result from cut/paste and copy/paste scenarios.

It takes advantage of the fact that the `paste` event allows the pasted data to be intercepted and modified just before being inserted on the page.  The paste data is parsed and searched for headings.  If there are headings, it checks for id duplication between any copied headings and headings already on the page.  If a duplicate is found, it chooses an appropriate way to resolve the duplication based on various attributes of the two headings. 
