### PR TITLE
Handle partial heading copies and id persistence

### DIFF
--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -139,9 +139,9 @@
           return newHeading;
         }
 
-        // if the text is identical (full copy), the original should retain its
+        // if the original heading text is not blank, the original should retain its
         // id and the new heading should get a new one.
-        if (newHeadingText === originalHeadingText) {
+        if (originalHeadingText) {
           newHeading.attributes.id = CKEDITOR.tools.getUniqueId();
           editor.fire(EVENT_NAMES.ID_ADDED);
           return newHeading;

--- a/tests/ids/add_ids.js
+++ b/tests/ids/add_ids.js
@@ -109,6 +109,31 @@
       editor.applyStyle(style);
 
       wait();
+    },
+
+    'test it will retain the id if a heading is converted to a non-heading and back': function() {
+      var bot = this.editorBot,
+        editor = this.editor,
+        paragraph,
+        heading,
+        headingStyle = new CKEDITOR.style({ element: 'h1' }),
+        paragraphStyle = new CKEDITOR.style({ element: 'p' }),
+        resumeAfter = bender.tools.resumeAfter,
+        startHtml = '<h1 id="12345">This paragraph will be converted^</h1>';
+
+      bot.setHtmlWithSelection(startHtml);
+      editor.execCommand('autoid');
+
+      heading = editor.editable().findOne('h1');
+      assert.areSame('12345', heading.getId());
+
+      // convert to non-heading
+      editor.applyStyle(paragraphStyle);
+
+      // convert back to heading and verify id still intact
+      editor.applyStyle(headingStyle);
+      heading = editor.editable().findOne('h1');
+      assert.areSame('12345', heading.getId());
     }
   });
 })();

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -148,8 +148,53 @@
       editor.execCommand('autoid');
 
       wait();
-    }
+    },
 
+    'test it gives partially copied headings a new id': function() {
+      // when a partial heading is copied and either a closing or opening
+      // heading tag is grabbed, clipboard automatically includes the closing
+      // tag, and adds the id if it was not already part of the selection.
+      var bot = this.editorBot,
+        editor = bot.editor,
+        heading,
+        headings,
+        resumeAfter = bender.tools.resumeAfter,
+        startHtml = '<h1 id="12345">Start Heading^</h1>',
+        partialHeading = '<h1 id="12345">Start';
+
+      bot.setHtmlWithSelection(startHtml);
+
+      editor.editable().fire('keydown', new CKEDITOR.dom.event({
+        keyCode: 13,
+        ctrlKey: false,
+        shiftKey: false
+      }));
+
+      resumeAfter(editor, 'allIdsComplete', function() {
+        heading = editor.editable().findOne('h1');
+
+        // verify original heading still has same id
+        assert.areSame('12345', heading.getAttribute('id'));
+
+        resumeAfter(editor, 'idAdded', function() {
+          headings = editor.editable().find('h1');
+          // get pasted heading (second heading on page)
+          heading = headings.getItem(1);
+
+          // verify pasted heading does not have the original id
+          assert.areNotSame('12345', heading.getAttribute('id'));
+        });
+
+        editor.execCommand('paste', partialHeading);
+
+        wait();
+      });
+
+      editor.execCommand('autoid');
+
+      // wait for initial id assignment for all headings to complete
+      wait();
+    }
   });
 
 })();

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -39,8 +39,6 @@
         shiftKey: false
       }));
 
-      console.log(editor.getData());
-
       resumeAfter(editor, 'allIdsComplete', function() {
         heading = editor.editable().findOne('h1');
 


### PR DESCRIPTION
It didn't take much to change things to handle partial cut / copy of headings, since CKEditor does the bulk of the work of fixing unpaired HTML tags.  Basically any time it has a partial tag, it will automatically provide the opposing tag, along with attributes.  Because of this, every partially copied heading will already have a copy of the id, so I just made a slight modification to existing logic in `resolveDuplicateIds` to handle it.

Also, in working on the issue of id persistence with changing an element to a non-heading and back, I realized that our main use-case is already covered.  As long as the user doesn't do anything to trigger the Advanced Content Filter (I was originally inadvertently triggering it by viewing source mode), the id will persist with the element, so conversion back to a heading will keep the same id.  I added a test to verify this.  
