### PR TITLE
Fix text paste

### DIFF
--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -103,10 +103,12 @@
 
         for (i = 0; i < pastedElements.length; i++) {
           element = pastedElements[i];
-          id = element.attributes.id;
-          originalHeading = checkForDuplicateId(id);
-          if (originalHeading) {
-            element = resolveDuplicateIds(element, originalHeading);
+          if (element.attributes) {
+            id = element.attributes.id;
+            originalHeading = checkForDuplicateId(id);
+            if (originalHeading) {
+              element = resolveDuplicateIds(element, originalHeading);
+            }
           }
         }
 

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -103,7 +103,7 @@
 
         for (i = 0; i < pastedElements.length; i++) {
           element = pastedElements[i];
-          if (element.attributes) {
+          if (element.type === CKEDITOR.NODE_ELEMENT) {
             id = element.attributes.id;
             originalHeading = checkForDuplicateId(id);
             if (originalHeading) {

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -21,6 +21,22 @@
       this.editor.execCommand('autoid');
     },
 
+    'test it can paste a regular text node': function() {
+      // verify we haven't broken regular copy / paste
+      var bot = this.editorBot,
+        editor = bot.editor,
+        startHtml = '<p>^</p>',
+        text = 'This is some text';
+
+      bot.setHtmlWithSelection(startHtml);
+
+      editor.execCommand('autoid');
+
+      editor.execCommand('paste', text);
+
+      assert.areSame('<p>This is some text</p>', editor.editable().getFirst().getOuterHtml());
+    },
+
     'test pasted heading id does not change when it is not a duplicate id': function() {
       var bot = this.editorBot,
         editor = bot.editor,

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -25,16 +25,24 @@
       // verify we haven't broken regular copy / paste
       var bot = this.editorBot,
         editor = bot.editor,
+        resumeAfter = bender.tools.resumeAfter,
         startHtml = '<p>^</p>',
         text = 'This is some text';
 
       bot.setHtmlWithSelection(startHtml);
 
+      resumeAfter(editor, 'allIdsComplete', function() {
+        editor.execCommand('paste', text);
+
+        wait(function () {
+          assert.areSame('<p>This is some text</p>', editor.editable().getFirst().getOuterHtml())
+        }, 10);
+
+      });
+
       editor.execCommand('autoid');
 
-      editor.execCommand('paste', text);
-
-      assert.areSame('<p>This is some text</p>', editor.editable().getFirst().getOuterHtml());
+      wait();
     },
 
     'test pasted heading id does not change when it is not a duplicate id': function() {

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -34,10 +34,7 @@
       resumeAfter(editor, 'allIdsComplete', function() {
         editor.execCommand('paste', text);
 
-        wait(function () {
-          assert.areSame('<p>This is some text</p>', editor.editable().getFirst().getOuterHtml())
-        }, 10);
-
+        assert.areSame('<p>This is some text</p>', editor.getData());
       });
 
       editor.execCommand('autoid');


### PR DESCRIPTION
Realized that I had broken copy/paste of pure text nodes.  This fixes it and adds a test to verify and prevent regression
