### PR TITLE
fix #14 - use bootstrap popover for failure case

### DIFF
--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -46,18 +46,19 @@ var addHeadingAnchors = {
 
   createPopover: function (anchor, headingId) {
     var popover;
-    var inputId = "popover-" + headingId; 
+    var inputId = "popover-" + headingId;
     popover = $(anchor).popover({
       container: "body",
       title: "Share a link to this section",
       content: function () {
-        return "<input id='" + inputId +  "' value='" + anchor.href + "'>";
+        return "<input id='" + inputId + "' value='" + anchor.href + "'>";
       },
       html: true,
       trigger: "manual" // this disables it for clicks
     });
 
     popover.on("shown", function (e) {
+      // the contents of popover are lazy-created, so this unfortunately needs to go here.
       var input = document.getElementById(inputId);
       input.focus();
       input.select();

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -60,6 +60,7 @@ var addHeadingAnchors = {
     popover.on("shown", function (e) {
       var input = document.getElementById(inputId);
       input.focus();
+      input.select();
     });
   },
 

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -1,6 +1,6 @@
 /*eslint-disable no-unused-vars*/
 var addHeadingAnchors = {
-/*eslint-enable no-unused-vars*/
+  /*eslint-enable no-unused-vars*/
 
   init: function (selector) {
     this.target = document.querySelector(selector);
@@ -45,19 +45,19 @@ var addHeadingAnchors = {
 
   createPopover: function (anchor) {
     $(anchor).popover({
-      container: 'body',
+      container: "body",
       title: "Share a link to this section",
       content: function () {
         return "<input value='" + anchor.href + "'>";
       },
       html: true,
-      //trigger: "manual" // this disables it for clicks
+      trigger: "manual" // this disables it for clicks
     });
   },
 
   registerClipboardHandler: function () {
     var clipboardErrorHandler = function (e) {
-
+      $(e.trigger).popover('show');
     };
     if (!this.handler) {
       this.handler = new Clipboard("a.headerLink");

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -62,17 +62,19 @@ var addHeadingAnchors = {
     popover.on("shown", function () {
       // the contents of popover are lazy-created, so this unfortunately needs to go here.
       var input = document.getElementById(inputId);
-      input.focus();
-      input.select();
-
-      input.addEventListener("blur", function () {
+      var blurHandler = function () {
         setTimeout(function () {
           // if the input hasn't been re-selected
           if (document.activeElement !== input) {
             $(anchor).popover("hide");
+            input.removeEventListener("blur", blurHandler);
           }
         }, timeToFade);
-      });
+      };
+
+      input.addEventListener("blur", blurHandler);
+      input.focus();
+      input.select();
     });
   },
 

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -1,3 +1,5 @@
+/* eslint-env jquery */
+
 /*eslint-disable no-unused-vars*/
 var addHeadingAnchors = {
   /*eslint-enable no-unused-vars*/
@@ -68,7 +70,8 @@ var addHeadingAnchors = {
           // if the input hasn't been re-selected
           if (document.activeElement !== input) {
             $(anchor).popover("hide");
-            // TODO consider not removing it here, and instead, move it to a different once handler for shown.
+            // TODO consider not removing it here
+            // instead, move it to a different one-time handler for shown.
             input.removeEventListener("blur", blurHandler);
           }
         }, timeToFade);

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -67,11 +67,11 @@ var addHeadingAnchors = {
           // if the input hasn't been re-selected
           if (document.activeElement !== input) {
             $(anchor).popover("hide");
+            // TODO consider not removing it here, and instead, move it to a different once handler for shown.
             input.removeEventListener("blur", blurHandler);
           }
         }, timeToFade);
       };
-
       input.addEventListener("blur", blurHandler);
       input.focus();
       input.select();

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -45,6 +45,7 @@ var addHeadingAnchors = {
 
   createPopover: function (anchor) {
     $(anchor).popover({
+      container: 'body',
       title: "Share a link to this section",
       content: function () {
         return "<input value='" + anchor.href + "'>";

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -17,6 +17,7 @@ var addHeadingAnchors = {
     headings.forEach(function (heading) {
       var anchor = this.createAnchor(heading.id);
       heading.appendChild(anchor);
+      this.createPopover(anchor);
     }.bind(this));
   },
 
@@ -25,8 +26,7 @@ var addHeadingAnchors = {
     var icon = document.createElement("i");
     var attributes = {
       href: "#" + id,
-      class: "headerLink",
-      title: "Permalink to this headline"
+      class: "headerLink"
     };
 
     icon.setAttribute("class", "icon-share");
@@ -44,7 +44,14 @@ var addHeadingAnchors = {
   },
 
   createPopover: function (anchor) {
-
+    $(anchor).popover({
+      title: "Share a link to this section",
+      content: function () {
+        return "<input value='" + anchor.href + "'>";
+      },
+      html: true,
+      //trigger: "manual" // this disables it for clicks
+    });
   },
 
   registerClipboardHandler: function () {
@@ -53,7 +60,7 @@ var addHeadingAnchors = {
     };
     if (!this.handler) {
       this.handler = new Clipboard("a.headerLink");
-      this.handler.on('error', clipboardErrorHandler);
+      this.handler.on("error", clipboardErrorHandler);
     }
   }
 };

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -43,9 +43,17 @@ var addHeadingAnchors = {
     return anchor;
   },
 
+  createPopover: function (anchor) {
+
+  },
+
   registerClipboardHandler: function () {
+    var clipboardErrorHandler = function (e) {
+
+    };
     if (!this.handler) {
       this.handler = new Clipboard("a.headerLink");
+      this.handler.on('error', clipboardErrorHandler);
     }
   }
 };

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -3,7 +3,8 @@ var addHeadingAnchors = {
   /*eslint-enable no-unused-vars*/
   TIME_TO_FADE: 1000,
 
-  init: function (selector) {
+  init: function (selector, popoverContainer) {
+    this.popoverContainer = popoverContainer || "body";
     this.target = document.querySelector(selector);
     if (this.target) {
       this.addAnchorsToHeadings();
@@ -50,7 +51,7 @@ var addHeadingAnchors = {
     var inputId = "popover-" + headingId;
     var timeToFade = this.TIME_TO_FADE;
     popover = $(anchor).popover({
-      container: "body",
+      container: this.popoverContainer,
       title: "Share a link to this section",
       content: function () {
         return "<input id='" + inputId + "' value='" + anchor.href + "'>";

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -1,6 +1,7 @@
 /*eslint-disable no-unused-vars*/
 var addHeadingAnchors = {
   /*eslint-enable no-unused-vars*/
+  TIME_TO_FADE: 1000,
 
   init: function (selector) {
     this.target = document.querySelector(selector);
@@ -47,6 +48,7 @@ var addHeadingAnchors = {
   createPopover: function (anchor, headingId) {
     var popover;
     var inputId = "popover-" + headingId;
+    var timeToFade = this.TIME_TO_FADE;
     popover = $(anchor).popover({
       container: "body",
       title: "Share a link to this section",
@@ -57,11 +59,20 @@ var addHeadingAnchors = {
       trigger: "manual" // this disables it for clicks
     });
 
-    popover.on("shown", function (e) {
+    popover.on("shown", function () {
       // the contents of popover are lazy-created, so this unfortunately needs to go here.
       var input = document.getElementById(inputId);
       input.focus();
       input.select();
+
+      input.addEventListener("blur", function () {
+        setTimeout(function () {
+          // if the input hasn't been re-selected
+          if (document.activeElement !== input) {
+            $(anchor).popover("hide");
+          }
+        }, timeToFade);
+      });
     });
   },
 

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -15,9 +15,10 @@ var addHeadingAnchors = {
     var headings = this.target.querySelectorAll(selectorString);
 
     headings.forEach(function (heading) {
-      var anchor = this.createAnchor(heading.id);
+      var id = heading.id;
+      var anchor = this.createAnchor(id);
       heading.appendChild(anchor);
-      this.createPopover(anchor);
+      this.createPopover(anchor, id);
     }.bind(this));
   },
 
@@ -43,21 +44,28 @@ var addHeadingAnchors = {
     return anchor;
   },
 
-  createPopover: function (anchor) {
-    $(anchor).popover({
+  createPopover: function (anchor, headingId) {
+    var popover;
+    var inputId = "popover-" + headingId; 
+    popover = $(anchor).popover({
       container: "body",
       title: "Share a link to this section",
       content: function () {
-        return "<input value='" + anchor.href + "'>";
+        return "<input id='" + inputId +  "' value='" + anchor.href + "'>";
       },
       html: true,
       trigger: "manual" // this disables it for clicks
+    });
+
+    popover.on("shown", function (e) {
+      var input = document.getElementById(inputId);
+      input.focus();
     });
   },
 
   registerClipboardHandler: function () {
     var clipboardErrorHandler = function (e) {
-      $(e.trigger).popover('show');
+      $(e.trigger).popover("show");
     };
     if (!this.handler) {
       this.handler = new Clipboard("a.headerLink");

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -30,7 +30,8 @@
         },
         "globals": {
             "Clipboard": true,
-            "chai": true
+            "chai": true,
+            "jquery": true
         }
     }
 }

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,37 +1,38 @@
 {
-    "name": "ckeditor-plugin-autoid-headings-viewer",
-    "version": "1.0.0",
-    "description": "",
-    "main": "add_heading_anchors.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "lint": "eslint --format compact .",
-        "fix-lint": "eslint --fix --format compact ."
+  "name": "ckeditor-plugin-autoid-headings-viewer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "add_heading_anchors.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint --format compact .",
+    "fix-lint": "eslint --fix --format compact ."
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "clipboard": "^1.5.15"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-string": "^1.3.0",
+    "eslint": "^3.10.1",
+    "eslint-config-walmart": "^1.1.0",
+    "eslint-plugin-filenames": "^1.1.0",
+    "mocha": "^3.1.2",
+    "sinon": "^1.17.6"
+  },
+  "eslintConfig": {
+    "extends": [
+      "walmart/configurations/es5-browser"
+    ],
+    "env": {
+      "mocha": true
     },
-    "author": "",
-    "license": "ISC",
-    "dependencies": {
-        "clipboard": "^1.5.15"
-    },
-    "devDependencies": {
-        "chai": "^3.5.0",
-        "chai-string": "^1.3.0",
-        "eslint": "^3.10.1",
-        "eslint-config-walmart": "^1.1.0",
-        "eslint-plugin-filenames": "^1.1.0",
-        "mocha": "^3.1.2"
-    },
-    "eslintConfig": {
-        "extends": [
-            "walmart/configurations/es5-browser"
-        ],
-        "env": {
-            "mocha": true
-        },
-        "globals": {
-            "Clipboard": true,
-            "chai": true,
-            "jquery": true
-        }
+    "globals": {
+      "Clipboard": true,
+      "chai": true,
+      "jquery": true
     }
+  }
 }

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -68,7 +68,7 @@ describe("addHeadingAnchors", function () {
         anchor.click();
 
         // assert the address bar changed
-        assert(window.location.hash, href);
+        assert.equal(window.location.hash, href);
       });
     });
 

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -5,7 +5,7 @@ var assert = chai.assert;
 describe("addHeadingAnchors", function () {
   before(function () {
     this.testArea = document.getElementById("testarea");
-    addHeadingAnchors.init("#testarea");
+    addHeadingAnchors.init("#testarea", "#popovers");
   });
 
   describe("HTML modification", function () {

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -72,7 +72,7 @@ describe("addHeadingAnchors", function () {
       });
     });
 
-    it("copies to clipboard when clicking on links", function (done) {
+    it("fires the clipboardjs error callback when clicking on links", function (done) {
       // a quick alternative to spying
       var callCount = 0;
       var expectedCallCount = 6;
@@ -110,6 +110,10 @@ describe("addHeadingAnchors", function () {
 
         anchor.click();
       });
+
+    });
+
+    it("does a bootstrap popover as the default error callback", function () {
 
     });
   });

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -112,10 +112,6 @@ describe("addHeadingAnchors", function () {
       });
 
     });
-
-    it("does a bootstrap popover as the default error callback", function () {
-
-    });
   });
 });
 

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -4,8 +4,8 @@ var assert = chai.assert;
 
 describe("addHeadingAnchors", function () {
   before(function () {
-    this.testArea = document.getElementById("testarea");
-    addHeadingAnchors.init("#testarea", "#popovers");
+    this.testArea = document.getElementById("test-add-heading-anchors");
+    addHeadingAnchors.init("#test-add-heading-anchors", "#test-add-heading-anchors .popovers");
   });
 
   describe("HTML modification", function () {

--- a/viewer/test/test-popovers-timing.js
+++ b/viewer/test/test-popovers-timing.js
@@ -4,6 +4,7 @@ var assert = chai.assert;
 
 describe("popover timing", function () {
   var NUM_HEADINGS = 6; // would be const, but you know.
+  var INTERACTION_TIMEOUT = 1000; // actually, it's 500
   var clock;
 
   before(function () {
@@ -22,6 +23,7 @@ describe("popover timing", function () {
 
   it("displays the popover, which then fades when the input is blurred", function () {
     var firstAnchor = this.clipboardAnchors[0];
+    var input;
     var popover;
 
     firstAnchor.click();
@@ -29,19 +31,32 @@ describe("popover timing", function () {
     // make sure nothing crazy happened like failed test cleanup
     assert.equal(1, this.testArea.querySelector(".popovers").children.length);
 
-    popover = this.testArea.querySelector(".popovers").children[0];
+    popover = this.testArea.querySelector(".popovers .popover");
 
     // click into the text area
 
+    input = popover.querySelector("input");
+    input.focus();
+
     // wait more than the timeout
+
+    clock.tick(INTERACTION_TIMEOUT);
 
     // check the popover is still visible
 
+    assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
+
     // focus out of the popover
+
+    input.blur();
 
     // wait for timeout
 
+    clock.tick(INTERACTION_TIMEOUT);
+
     // check popover is hidden
+
+    assert.isFalse(popover.classList.contains("in"), "popover is not hidden");
 
   });
 

--- a/viewer/test/test-popovers-timing.js
+++ b/viewer/test/test-popovers-timing.js
@@ -3,7 +3,7 @@
 var assert = chai.assert;
 
 describe("popover timing", function () {
-  var INTERACTION_TIMEOUT = 1000; // actually, it's 500
+  var INTERACTION_TIMEOUT = 1000;
   var clock;
 
   before(function () {

--- a/viewer/test/test-popovers-timing.js
+++ b/viewer/test/test-popovers-timing.js
@@ -33,28 +33,22 @@ describe("popover timing", function () {
     popover = this.testArea.querySelector(".popovers .popover");
 
     // click into the text area
-
     input = popover.querySelector("input");
     input.focus();
 
     // wait more than the timeout
-
     clock.tick(INTERACTION_TIMEOUT);
 
     // check the popover is still visible
-
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
     // focus out of the popover
-
     input.blur();
 
     // wait for timeout
-
     clock.tick(INTERACTION_TIMEOUT);
 
     // check popover is hidden
-
     assert.isFalse(popover.classList.contains("in"), "popover is not hidden");
 
   });

--- a/viewer/test/test-popovers-timing.js
+++ b/viewer/test/test-popovers-timing.js
@@ -1,0 +1,48 @@
+/* global addHeadingAnchors:false sinon:false */
+
+var assert = chai.assert;
+
+describe("popover timing", function () {
+  var NUM_HEADINGS = 6; // would be const, but you know.
+  var clock;
+
+  before(function () {
+    this.testArea = document.getElementById("test-popovers-timing");
+    addHeadingAnchors.init("#test-popovers-timing", "#test-popovers-timing .popovers");
+    this.clipboardAnchors = this.testArea.querySelectorAll("a[data-clipboard-text]");
+  });
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function () {
+  //  clock.restore();
+  });
+
+  it("displays the popover, which then fades when the input is blurred", function () {
+    var firstAnchor = this.clipboardAnchors[0];
+    var popover;
+
+    firstAnchor.click();
+
+    // make sure nothing crazy happened like failed test cleanup
+    assert.equal(1, this.testArea.querySelector(".popovers").children.length);
+
+    popover = this.testArea.querySelector(".popovers").children[0];
+
+    // click into the text area
+
+    // wait more than the timeout
+
+    // check the popover is still visible
+
+    // focus out of the popover
+
+    // wait for timeout
+
+    // check popover is hidden
+
+  });
+
+});

--- a/viewer/test/test-popovers-timing.js
+++ b/viewer/test/test-popovers-timing.js
@@ -3,7 +3,6 @@
 var assert = chai.assert;
 
 describe("popover timing", function () {
-  var NUM_HEADINGS = 6; // would be const, but you know.
   var INTERACTION_TIMEOUT = 1000; // actually, it's 500
   var clock;
 

--- a/viewer/test/test-popovers.js
+++ b/viewer/test/test-popovers.js
@@ -3,6 +3,8 @@
 var assert = chai.assert;
 
 describe("popovers", function () {
+  var NUM_HEADINGS = 6; // would be const, but you know.
+
   before(function () {
     this.testArea = document.getElementById("test-popovers");
     addHeadingAnchors.init("#test-popovers", "#test-popovers .popovers");
@@ -18,7 +20,7 @@ describe("popovers", function () {
 
     popoverChildCount = this.testArea.querySelector(".popovers").children.length;
 
-    assert.equal(popoverChildCount, 6);
+    assert.equal(popoverChildCount, NUM_HEADINGS);
   });
 
 });

--- a/viewer/test/test-popovers.js
+++ b/viewer/test/test-popovers.js
@@ -1,0 +1,26 @@
+/* global addHeadingAnchors:false */
+
+var assert = chai.assert;
+
+describe("popovers", function () {
+  before(function () {
+    this.testArea = document.getElementById("test-popovers");
+    addHeadingAnchors.init("#test-popovers", "#test-popovers .popovers");
+    this.clipboardAnchors = this.testArea.querySelectorAll("a[data-clipboard-text]");
+  });
+
+  it("creates the popover html when we 'click' each share button", function () {
+    var popoverChildCount = 0;
+
+    this.clipboardAnchors.forEach(function assertClickCreatesPopover(anchor) {
+      anchor.click();
+    });
+
+    popoverChildCount = this.testArea.querySelector(".popovers").children.length;
+
+    assert.equal(popoverChildCount, 6);
+  });
+
+});
+
+

--- a/viewer/test/test-popovers.js
+++ b/viewer/test/test-popovers.js
@@ -1,4 +1,4 @@
-/* global addHeadingAnchors:false sinon:false */
+/* global addHeadingAnchors:false */
 
 var assert = chai.assert;
 

--- a/viewer/test/test-popovers.js
+++ b/viewer/test/test-popovers.js
@@ -23,21 +23,4 @@ describe("popovers", function () {
     assert.equal(popoverChildCount, NUM_HEADINGS);
   });
 
-  describe("mocked timer cases", function () {
-
-    beforeEach(function () {
-      this.clock = sinon.useFakeTimers();
-    });
-
-    afterEach(function () {
-      this.clock.restore();
-    });
-
-
-    it("displays the popover, which then fades when the input is blurred", function () {
-
-    });
-
-  });
-
 });

--- a/viewer/test/test-popovers.js
+++ b/viewer/test/test-popovers.js
@@ -1,4 +1,4 @@
-/* global addHeadingAnchors:false */
+/* global addHeadingAnchors:false sinon:false */
 
 var assert = chai.assert;
 
@@ -23,6 +23,21 @@ describe("popovers", function () {
     assert.equal(popoverChildCount, NUM_HEADINGS);
   });
 
+  describe("mocked timer cases", function () {
+
+    beforeEach(function () {
+      this.clock = sinon.useFakeTimers();
+    });
+
+    afterEach(function () {
+      this.clock.restore();
+    });
+
+
+    it("displays the popover, which then fades when the input is blurred", function () {
+
+    });
+
+  });
+
 });
-
-

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -51,7 +51,7 @@
   <script src="node_modules/chai/chai.js"></script>
   <script src="node_modules/chai-string/chai-string.js"></script>
   <script src="node_modules/sinon-chai/lib/sinon-chai.js"></script>
-  <script src="node_modules/sinon/lib/sinon.js"></script>
+  <script src="node_modules/sinon/pkg/sinon.js"></script>
   <script>mocha.setup('bdd')</script>
 
   <!--other dependencies-->

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -80,9 +80,9 @@
   <script src='add-heading-anchors.js'></script>
 
   <!--the actual test suite-->
+  <script src='test/test-popovers-timing.js'></script>
   <script src='test/test-add-heading-anchors.js'></script>
   <script src='test/test-popovers.js'></script>
-  <script src='test/test-popovers-timing.js'></script>
 
   <script>
       mocha.run();

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -1,13 +1,33 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Mocha Tests</title>
-    <link rel="stylesheet" href="node_modules/mocha/mocha.css">
-    <link href="https://maxcdn.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet" integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css" integrity="sha256-bNPGnNxsIr8mZ4p5VH3uYQorlucOUehl8ml0jm1LZ2I=" crossorigin="anonymous" />
-  </head>
-  <body>
-    <div id="test-add-heading-anchors">
+
+<head>
+  <title>Mocha Tests</title>
+  <link rel="stylesheet" href="node_modules/mocha/mocha.css">
+  <link href="https://maxcdn.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet" integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
+    crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css" integrity="sha256-bNPGnNxsIr8mZ4p5VH3uYQorlucOUehl8ml0jm1LZ2I="
+    crossorigin="anonymous" />
+</head>
+
+<body>
+  <div id="test-add-heading-anchors">
+    <h1 id='h1'>Heading 1</h1>
+    <h2 id='h2'>Heading 2</h2>
+    <h3 id='h3'>Heading 3</h3>
+    <h4 id='h4'>Heading 4</h4>
+    <h5 id='h5'>Heading 5</h5>
+    <h6 id='h6'>Heading 6</h6>
+
+    <h1>No-id Heading 1</h1>
+    <h2>No-id Heading 2</h2>
+    <h3>No-id Heading 3</h3>
+    <h4>No-id Heading 4</h4>
+    <h5>No-id Heading 5</h5>
+    <h6>No-id Heading 6</h6>
+    <div class="popovers"></div>
+  </div>
+  <div id="test-popovers">
         <h1 id='h1'>Heading 1</h1>
         <h2 id='h2'>Heading 2</h2>
         <h3 id='h3'>Heading 3</h3>
@@ -22,32 +42,35 @@
         <h5>No-id Heading 5</h5>
         <h6>No-id Heading 6</h6>
         <div class="popovers"></div>
-      </div>
+    </div>
 
 
-    <div id="mocha"></div>
 
-    <!--testing libs-->
-    <script src="node_modules/mocha/mocha.js"></script>
-    <script src="node_modules/chai/chai.js"></script>
-    <script src="node_modules/chai-string/chai-string.js"></script>
-    <script src="node_modules/sinon-chai/lib/sinon-chai.js"></script>
-    <script src="node_modules/sinon/lib/sinon.js"></script>
-    <script>mocha.setup('bdd')</script>
+  <div id="mocha"></div>
 
-    <!--other dependencies-->
-    <script src="https://code.jquery.com/jquery-1.12.4.js" integrity="sha256-Qw82+bXyGq6MydymqBxNPYTaUXXq7c8v3CwiYwLLNXU=" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js" integrity="sha384-vOWIrgFbxIPzY09VArRHMsxned7WiY6hzIPtAIIeTFuii9y3Cr6HE6fcHXy5CFhc" crossorigin="anonymous"></script>
-    <script src="node_modules/clipboard/dist/clipboard.min.js"></script>
+  <!--testing libs-->
+  <script src="node_modules/mocha/mocha.js"></script>
+  <script src="node_modules/chai/chai.js"></script>
+  <script src="node_modules/chai-string/chai-string.js"></script>
+  <script src="node_modules/sinon-chai/lib/sinon-chai.js"></script>
+  <script src="node_modules/sinon/lib/sinon.js"></script>
+  <script>mocha.setup('bdd')</script>
 
-    <!--the plugin being tested-->
-    <script src='add-heading-anchors.js'></script>
+  <!--other dependencies-->
+  <script src="https://code.jquery.com/jquery-1.12.4.js" integrity="sha256-Qw82+bXyGq6MydymqBxNPYTaUXXq7c8v3CwiYwLLNXU=" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js" integrity="sha384-vOWIrgFbxIPzY09VArRHMsxned7WiY6hzIPtAIIeTFuii9y3Cr6HE6fcHXy5CFhc"
+    crossorigin="anonymous"></script>
+  <script src="node_modules/clipboard/dist/clipboard.min.js"></script>
 
-    <!--the actual test suite-->
-    <script src='test/test-add-heading-anchors.js'></script>
+  <!--the plugin being tested-->
+  <script src='add-heading-anchors.js'></script>
 
-    <script>
+  <!--the actual test suite-->
+  <script src='test/test-add-heading-anchors.js'></script>
+
+  <script>
       mocha.run();
     </script>
-  </body>
+</body>
+
 </html>

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css" integrity="sha256-bNPGnNxsIr8mZ4p5VH3uYQorlucOUehl8ml0jm1LZ2I=" crossorigin="anonymous" />
   </head>
   <body>
-    <div id="testarea">
+    <div id="test-add-heading-anchors">
         <h1 id='h1'>Heading 1</h1>
         <h2 id='h2'>Heading 2</h2>
         <h3 id='h3'>Heading 3</h3>
@@ -21,8 +21,9 @@
         <h4>No-id Heading 4</h4>
         <h5>No-id Heading 5</h5>
         <h6>No-id Heading 6</h6>
+        <div class="popovers"></div>
       </div>
-      <div id="popovers"></div>
+
 
     <div id="mocha"></div>
 

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -28,21 +28,37 @@
     <div class="popovers"></div>
   </div>
   <div id="test-popovers">
-        <h1 id='h1'>Heading 1</h1>
-        <h2 id='h2'>Heading 2</h2>
-        <h3 id='h3'>Heading 3</h3>
-        <h4 id='h4'>Heading 4</h4>
-        <h5 id='h5'>Heading 5</h5>
-        <h6 id='h6'>Heading 6</h6>
+      <h1 id='h1'>Heading 1</h1>
+      <h2 id='h2'>Heading 2</h2>
+      <h3 id='h3'>Heading 3</h3>
+      <h4 id='h4'>Heading 4</h4>
+      <h5 id='h5'>Heading 5</h5>
+      <h6 id='h6'>Heading 6</h6>
 
-        <h1>No-id Heading 1</h1>
-        <h2>No-id Heading 2</h2>
-        <h3>No-id Heading 3</h3>
-        <h4>No-id Heading 4</h4>
-        <h5>No-id Heading 5</h5>
-        <h6>No-id Heading 6</h6>
-        <div class="popovers"></div>
-    </div>
+      <h1>No-id Heading 1</h1>
+      <h2>No-id Heading 2</h2>
+      <h3>No-id Heading 3</h3>
+      <h4>No-id Heading 4</h4>
+      <h5>No-id Heading 5</h5>
+      <h6>No-id Heading 6</h6>
+      <div class="popovers"></div>
+  </div>
+  <div id="test-popovers-timing">
+      <h1 id='h1'>Heading 1</h1>
+      <h2 id='h2'>Heading 2</h2>
+      <h3 id='h3'>Heading 3</h3>
+      <h4 id='h4'>Heading 4</h4>
+      <h5 id='h5'>Heading 5</h5>
+      <h6 id='h6'>Heading 6</h6>
+
+      <h1>No-id Heading 1</h1>
+      <h2>No-id Heading 2</h2>
+      <h3>No-id Heading 3</h3>
+      <h4>No-id Heading 4</h4>
+      <h5>No-id Heading 5</h5>
+      <h6>No-id Heading 6</h6>
+      <div class="popovers"></div>
+  </div>
 
   <div id="mocha"></div>
 

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -82,6 +82,7 @@
   <!--the actual test suite-->
   <script src='test/test-add-heading-anchors.js'></script>
   <script src='test/test-popovers.js'></script>
+  <script src='test/test-popovers-timing.js'></script>
 
   <script>
       mocha.run();

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -21,7 +21,8 @@
         <h4>No-id Heading 4</h4>
         <h5>No-id Heading 5</h5>
         <h6>No-id Heading 6</h6>
-    </div>
+      </div>
+      <div id="popovers"></div>
 
     <div id="mocha"></div>
 

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -44,8 +44,6 @@
         <div class="popovers"></div>
     </div>
 
-
-
   <div id="mocha"></div>
 
   <!--testing libs-->
@@ -67,6 +65,7 @@
 
   <!--the actual test suite-->
   <script src='test/test-add-heading-anchors.js'></script>
+  <script src='test/test-popovers.js'></script>
 
   <script>
       mocha.run();

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -29,6 +29,8 @@
     <script src="node_modules/mocha/mocha.js"></script>
     <script src="node_modules/chai/chai.js"></script>
     <script src="node_modules/chai-string/chai-string.js"></script>
+    <script src="node_modules/sinon-chai/lib/sinon-chai.js"></script>
+    <script src="node_modules/sinon/lib/sinon.js"></script>
     <script>mocha.setup('bdd')</script>
 
     <!--other dependencies-->


### PR DESCRIPTION
![screen shot 2016-11-16 at 2 48 21 pm](https://cloud.githubusercontent.com/assets/2367533/20536965/14c933e2-b0a0-11e6-9778-f483bda8ad9a.png)

When clipboard access is not allowed (due to browser support, or permissions), show a popover instead that allows the user to manually copy/paste the link