### PR TITLE
Fix #16 - nodeList.forEach

### DIFF
--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -18,7 +18,7 @@ var addHeadingAnchors = {
     var selectorString = "h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]";
     var headings = this.target.querySelectorAll(selectorString);
 
-    headings.forEach(function (heading) {
+    Array.prototype.forEach.call(headings, function (heading) {
       var id = heading.id;
       var anchor = this.createAnchor(id);
       heading.appendChild(anchor);

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -42,7 +42,7 @@ describe("addHeadingAnchors", function () {
         assert.endsWith(clipboardDataAttribute, "#" + heading.getAttribute("id"));
       };
 
-      this.headingsWithAnId.forEach(assertHasCopyLink);
+      Array.prototype.forEach.call(this.headingsWithAnId, assertHasCopyLink);
     });
 
     it("did not add anchors inside non-id headings", function () {
@@ -53,7 +53,7 @@ describe("addHeadingAnchors", function () {
         assert.isNull(anchor);
       };
 
-      this.headingsWithoutAnId.forEach(assertNoAnchorAdded);
+      Array.prototype.forEach.call(this.headingsWithoutAnId, assertNoAnchorAdded);
     });
   });
 
@@ -63,7 +63,7 @@ describe("addHeadingAnchors", function () {
     });
 
     it("changes the address bar when clicking on links", function () {
-      this.clipboardAnchors.forEach(function assertClipboardCopy(anchor) {
+      Array.prototype.forEach.call(this.clipboardAnchors, function assertClipboardCopy(anchor) {
         var href = anchor.getAttribute("href");
         anchor.click();
 
@@ -77,7 +77,7 @@ describe("addHeadingAnchors", function () {
       var callCount = 0;
       var expectedCallCount = 6;
 
-      this.clipboardAnchors.forEach(function (anchor) {
+      Array.prototype.forEach.call(this.clipboardAnchors, function (anchor) {
 
         // Register a one time event handler to check the event text
         // this isn't a very good test due to the limitations.

--- a/viewer/test/test-popovers.js
+++ b/viewer/test/test-popovers.js
@@ -14,7 +14,7 @@ describe("popovers", function () {
   it("creates the popover html when we 'click' each share button", function () {
     var popoverChildCount = 0;
 
-    this.clipboardAnchors.forEach(function assertClickCreatesPopover(anchor) {
+    Array.prototype.forEach.call(this.clipboardAnchors, function assertClickCreatesPopover(anchor) {
       anchor.click();
     });
 


### PR DESCRIPTION
Use Array.prototype.forEach instead (for now)

Review this after #15 is merged

testing notes:

opened the test page in Firefox & IE.  the clipboard anchors are now added.  Most of the Firefox tests pass, except for one unrelated timing issue around clicking anchors and having window.href hash actually update in time.  

 IE11 fails due to #18 