### PR TITLE
Fix #18 - IE11 failure detection

### DIFF
--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -18,7 +18,7 @@ var addHeadingAnchors = {
     var selectorString = "h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]";
     var headings = this.target.querySelectorAll(selectorString);
 
-    headings.forEach(function (heading) {
+    Array.prototype.forEach.call(headings, function (heading) {
       var id = heading.id;
       var anchor = this.createAnchor(id);
       heading.appendChild(anchor);

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -56,7 +56,7 @@ var addHeadingAnchors = {
       container: this.popoverContainer,
       title: "Share a link to this section",
       content: function () {
-        return "<input id='" + inputId + "' value='" + anchor.href + "'>";
+        return "<input readonly id='" + inputId + "' value='" + anchor.href + "'>";
       },
       html: true,
       trigger: "manual" // this disables it for clicks

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -89,6 +89,14 @@ var addHeadingAnchors = {
     if (!this.handler) {
       this.handler = new Clipboard("a.headerLink");
       this.handler.on("error", clipboardErrorHandler);
+      this.handler.on("success", function (e) {
+        var originalText = e.text;
+        var clipboardContent = window.clipboardData.getData("Text");
+        if (originalText !== clipboardContent) {
+          // actually, this was a failure.
+          clipboardErrorHandler(e);
+        }
+      });
     }
   }
 };

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -10,7 +10,7 @@ var addHeadingAnchors = {
     this.target = document.querySelector(selector);
     if (this.target) {
       this.addAnchorsToHeadings();
-      this.registerClipboardHandler();
+      this.registerClipboardHandlers();
     }
   },
 
@@ -82,21 +82,24 @@ var addHeadingAnchors = {
     });
   },
 
-  registerClipboardHandler: function () {
+  registerClipboardHandlers: function () {
     var clipboardErrorHandler = function (e) {
       $(e.trigger).popover("show");
     };
+
+    var ensureSuccessHandler = function (e) {
+      var originalText = e.text;
+      var clipboardContent = window.clipboardData.getData("Text");
+      if (originalText !== clipboardContent) {
+        // actually, this was a failure.
+        clipboardErrorHandler(e);
+      }
+    };
+
     if (!this.handler) {
       this.handler = new Clipboard("a.headerLink");
       this.handler.on("error", clipboardErrorHandler);
-      this.handler.on("success", function (e) {
-        var originalText = e.text;
-        var clipboardContent = window.clipboardData.getData("Text");
-        if (originalText !== clipboardContent) {
-          // actually, this was a failure.
-          clipboardErrorHandler(e);
-        }
-      });
+      this.handler.on("success", ensureSuccessHandler);
     }
   }
 };

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -42,7 +42,7 @@ describe("addHeadingAnchors", function () {
         assert.endsWith(clipboardDataAttribute, "#" + heading.getAttribute("id"));
       };
 
-      this.headingsWithAnId.forEach(assertHasCopyLink);
+      Array.prototype.forEach.call(this.headingsWithAnId, assertHasCopyLink);
     });
 
     it("did not add anchors inside non-id headings", function () {
@@ -53,7 +53,7 @@ describe("addHeadingAnchors", function () {
         assert.isNull(anchor);
       };
 
-      this.headingsWithoutAnId.forEach(assertNoAnchorAdded);
+      Array.prototype.forEach.call(this.headingsWithoutAnId, assertNoAnchorAdded);
     });
   });
 
@@ -63,7 +63,7 @@ describe("addHeadingAnchors", function () {
     });
 
     it("changes the address bar when clicking on links", function () {
-      this.clipboardAnchors.forEach(function assertClipboardCopy(anchor) {
+      Array.prototype.forEach.call(this.clipboardAnchors, function assertClipboardCopy(anchor) {
         var href = anchor.getAttribute("href");
         anchor.click();
 
@@ -77,7 +77,7 @@ describe("addHeadingAnchors", function () {
       var callCount = 0;
       var expectedCallCount = 6;
 
-      this.clipboardAnchors.forEach(function (anchor) {
+      Array.prototype.forEach.call(this.clipboardAnchors, function (anchor) {
 
         // Register a one time event handler to check the event text
         // this isn't a very good test due to the limitations.

--- a/viewer/test/test-popovers.js
+++ b/viewer/test/test-popovers.js
@@ -14,7 +14,7 @@ describe("popovers", function () {
   it("creates the popover html when we 'click' each share button", function () {
     var popoverChildCount = 0;
 
-    this.clipboardAnchors.forEach(function assertClickCreatesPopover(anchor) {
+    Array.prototype.forEach.call(this.clipboardAnchors, function assertClickCreatesPopover(anchor) {
       anchor.click();
     });
 

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -74,7 +74,7 @@
   <script src="https://code.jquery.com/jquery-1.12.4.js" integrity="sha256-Qw82+bXyGq6MydymqBxNPYTaUXXq7c8v3CwiYwLLNXU=" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js" integrity="sha384-vOWIrgFbxIPzY09VArRHMsxned7WiY6hzIPtAIIeTFuii9y3Cr6HE6fcHXy5CFhc"
     crossorigin="anonymous"></script>
-  <script src="node_modules/clipboard/dist/clipboard.min.js"></script>
+  <script src="node_modules/clipboard/dist/clipboard.js"></script>
 
   <!--the plugin being tested-->
   <script src='add-heading-anchors.js'></script>


### PR DESCRIPTION
When you decline the IE11 permissions dialog, the event still is a success.

Add a success handler that checks the clipboard content vs. the text that was supposed to be in the clipboard.  