### PR TITLE
Fix #17 - replace blur handlers with less flaky

### DIFF
--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -63,6 +63,8 @@ var addHeadingAnchors = {
     });
 
     popover.on("shown", function () {
+      $("a.headerLink").not(this).popover("hide");
+
       // the contents of popover are lazy-created, so this unfortunately needs to go here.
       var input = document.getElementById(inputId);
       var blurHandler = function () {
@@ -70,9 +72,6 @@ var addHeadingAnchors = {
           // if the input hasn't been re-selected
           if (document.activeElement !== input) {
             $(anchor).popover("hide");
-            // TODO consider not removing it here
-            // instead, move it to a different one-time handler for shown.
-            input.removeEventListener("blur", blurHandler);
           }
         }, timeToFade);
       };

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -10,7 +10,7 @@ var addHeadingAnchors = {
     if (this.target) {
       this.addAnchorsToHeadings();
       this.registerClipboardHandlers();
-      this.registerDismissPopoverHandler()
+      this.registerDismissPopoverHandler();
     }
   },
 
@@ -93,7 +93,7 @@ var addHeadingAnchors = {
 
   registerDismissPopoverHandler: function () {
     $(this.target).click(function (e) {
-      if ($('a.headerLink').has(e.target).length === 0) {
+      if ($("a.headerLink").has(e.target).length === 0) {
         $("a.headerLink").popover("hide");
       }
     });

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -79,7 +79,7 @@ var addHeadingAnchors = {
       var originalText = e.text;
       var clipboardContent = window.clipboardData.getData("Text");
       if (originalText !== clipboardContent) {
-        // actually, this was a failure.
+        // actually, this was a failure because the content didn't actually make it to clipboardData
         clipboardErrorHandler(e);
       }
     };

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -93,6 +93,7 @@ var addHeadingAnchors = {
 
   registerDismissPopoverHandler: function () {
     $(this.target).click(function (e) {
+      // if clicking a non-popover-ed element
       if ($("a.headerLink").has(e.target).length === 0) {
         $("a.headerLink").popover("hide");
       }

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -62,6 +62,8 @@ var addHeadingAnchors = {
     });
 
     popover.on("shown", function () {
+      // Hide all other popovers
+      // `this` is the anchor that triggered the shown event.
       $("a.headerLink").not(this).popover("hide");
       // the contents of popover are lazy-created, so this unfortunately needs to go here.
       var input = document.getElementById(inputId);

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -3,7 +3,6 @@
 /*eslint-disable no-unused-vars*/
 var addHeadingAnchors = {
   /*eslint-enable no-unused-vars*/
-  TIME_TO_FADE: 1000,
 
   init: function (selector, popoverContainer) {
     this.popoverContainer = popoverContainer || "body";
@@ -11,6 +10,7 @@ var addHeadingAnchors = {
     if (this.target) {
       this.addAnchorsToHeadings();
       this.registerClipboardHandlers();
+      this.registerDismissPopoverHandler()
     }
   },
 
@@ -51,7 +51,6 @@ var addHeadingAnchors = {
   createPopover: function (anchor, headingId) {
     var popover;
     var inputId = "popover-" + headingId;
-    var timeToFade = this.TIME_TO_FADE;
     popover = $(anchor).popover({
       container: this.popoverContainer,
       title: "Share a link to this section",
@@ -64,18 +63,8 @@ var addHeadingAnchors = {
 
     popover.on("shown", function () {
       $("a.headerLink").not(this).popover("hide");
-
       // the contents of popover are lazy-created, so this unfortunately needs to go here.
       var input = document.getElementById(inputId);
-      var blurHandler = function () {
-        setTimeout(function () {
-          // if the input hasn't been re-selected
-          if (document.activeElement !== input) {
-            $(anchor).popover("hide");
-          }
-        }, timeToFade);
-      };
-      input.addEventListener("blur", blurHandler);
       input.focus();
       input.select();
     });
@@ -100,5 +89,13 @@ var addHeadingAnchors = {
       this.handler.on("error", clipboardErrorHandler);
       this.handler.on("success", ensureSuccessHandler);
     }
+  },
+
+  registerDismissPopoverHandler: function () {
+    $(this.target).click(function (e) {
+      if ($('a.headerLink').has(e.target).length === 0) {
+        $("a.headerLink").popover("hide");
+      }
+    });
   }
 };

--- a/viewer/test/test-popovers-hiding.js
+++ b/viewer/test/test-popovers-hiding.js
@@ -20,16 +20,11 @@ describe("popover timing", function () {
 
     // make sure nothing crazy happened like failed test cleanup
     assert.equal(1, this.testArea.querySelector(".popovers").children.length);
-
     popover = this.testArea.querySelector(".popovers .popover");
-
-    // check the popover is still visible
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
     // click something else
     unrelatedHeading.click();
-
-    // check popover is hidden
     assert.isFalse(popover.classList.contains("in"), "popover is hidden");
 
   });
@@ -42,10 +37,7 @@ describe("popover timing", function () {
 
     // make sure nothing crazy happened like failed test cleanup
     assert.equal(1, this.testArea.querySelector(".popovers").children.length);
-
     popover = this.testArea.querySelector(".popovers .popover");
-
-    // check the popover is still visible
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
     // click on the popover
@@ -53,8 +45,6 @@ describe("popover timing", function () {
 
     // click on the anchor again
     firstAnchor.click();
-
-    // check popover is not hidden
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
   });
 
@@ -69,13 +59,10 @@ describe("popover timing", function () {
     assert.equal(1, this.testArea.querySelector(".popovers").children.length);
     popover = this.testArea.querySelector(".popovers .popover");
 
-    // check the popover is still visible
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
     // click to trigger other popover
     secondAnchor.click();
-
-    // check popover is hidden
     assert.isFalse(popover.classList.contains("in"), "popover is hidden");
   });
 

--- a/viewer/test/test-popovers-hiding.js
+++ b/viewer/test/test-popovers-hiding.js
@@ -6,7 +6,8 @@ describe("popover timing", function () {
   before(function () {
     this.testArea = document.getElementById("test-popovers-timing");
     addHeadingAnchors.init("#test-popovers-timing", "#test-popovers-timing .popovers");
-    this.firstClipboardAnchor = this.testArea.querySelector("a[data-clipboard-text]");
+    this.firstClipboardAnchor = this.testArea.querySelectorAll("a[data-clipboard-text]")[0];
+    this.secondClipboardAnchor = this.testArea.querySelectorAll("a[data-clipboard-text]")[1];
     this.unrelatedHeading = this.testArea.querySelector("h2");
   });
 
@@ -26,7 +27,6 @@ describe("popover timing", function () {
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
     // click something else
-
     unrelatedHeading.click();
 
     // check popover is hidden
@@ -49,16 +49,37 @@ describe("popover timing", function () {
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
     // click on the popover
-
     popover.click();
 
     // click on the anchor again
+    firstAnchor.click();
+
+    // check popover is not hidden
+    assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
+  });
+
+  it("displays the popover and does not blur if a different popover is shown", function () {
+    var firstAnchor = this.firstClipboardAnchor;
+    var secondAnchor = this.secondClipboardAnchor;
+    var popover;
 
     firstAnchor.click();
 
-    // check popover is hidden
+    // make sure nothing crazy happened like failed test cleanup
+    assert.equal(1, this.testArea.querySelector(".popovers").children.length);
+    popover = this.testArea.querySelector(".popovers .popover");
+
+    // check the popover is still visible
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
+    // click to trigger other popover
+    secondAnchor.click();
+
+    // click on the anchor again
+    firstAnchor.click();
+
+    // check popover is hidden
+    assert.isFalse(popover.classList.contains("in"), "popover is now hidden");
   });
 
 });

--- a/viewer/test/test-popovers-hiding.js
+++ b/viewer/test/test-popovers-hiding.js
@@ -4,8 +4,8 @@ var assert = chai.assert;
 
 describe("popover timing", function () {
   before(function () {
-    this.testArea = document.getElementById("test-popovers-timing");
-    addHeadingAnchors.init("#test-popovers-timing", "#test-popovers-timing .popovers");
+    this.testArea = document.getElementById("test-popovers-hiding");
+    addHeadingAnchors.init("#test-popovers-hiding", "#test-popovers-hiding .popovers");
     this.firstClipboardAnchor = this.testArea.querySelectorAll("a[data-clipboard-text]")[0];
     this.secondClipboardAnchor = this.testArea.querySelectorAll("a[data-clipboard-text]")[1];
     this.unrelatedHeading = this.testArea.querySelector("h2");

--- a/viewer/test/test-popovers-hiding.js
+++ b/viewer/test/test-popovers-hiding.js
@@ -10,7 +10,7 @@ describe("popover timing", function () {
     this.unrelatedHeading = this.testArea.querySelector("h2");
   });
 
-  it("displays the popover, which then fades when the input is blurred", function () {
+  it("displays the popover, which then fades when something else is clicked", function () {
     var firstAnchor = this.firstClipboardAnchor;
     var unrelatedHeading = this.unrelatedHeading;
     var popover;
@@ -30,7 +30,34 @@ describe("popover timing", function () {
     unrelatedHeading.click();
 
     // check popover is hidden
-    assert.isFalse(popover.classList.contains("in"), "popover is not hidden");
+    assert.isFalse(popover.classList.contains("in"), "popover is now hidden");
+
+  });
+
+  it("displays the popover and does not blur if the popover itself is clicked", function () {
+    var firstAnchor = this.firstClipboardAnchor;
+    var popover;
+
+    firstAnchor.click();
+
+    // make sure nothing crazy happened like failed test cleanup
+    assert.equal(1, this.testArea.querySelector(".popovers").children.length);
+
+    popover = this.testArea.querySelector(".popovers .popover");
+
+    // check the popover is still visible
+    assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
+
+    // click on the popover
+
+    popover.click();
+
+    // click on the anchor again
+
+    firstAnchor.click();
+
+    // check popover is hidden
+    assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
   });
 

--- a/viewer/test/test-popovers-hiding.js
+++ b/viewer/test/test-popovers-hiding.js
@@ -30,7 +30,7 @@ describe("popover timing", function () {
     unrelatedHeading.click();
 
     // check popover is hidden
-    assert.isFalse(popover.classList.contains("in"), "popover is now hidden");
+    assert.isFalse(popover.classList.contains("in"), "popover is hidden");
 
   });
 
@@ -76,7 +76,7 @@ describe("popover timing", function () {
     secondAnchor.click();
 
     // check popover is hidden
-    assert.isFalse(popover.classList.contains("in"), "popover is now hidden");
+    assert.isFalse(popover.classList.contains("in"), "popover is hidden");
   });
 
 });

--- a/viewer/test/test-popovers-hiding.js
+++ b/viewer/test/test-popovers-hiding.js
@@ -75,9 +75,6 @@ describe("popover timing", function () {
     // click to trigger other popover
     secondAnchor.click();
 
-    // click on the anchor again
-    firstAnchor.click();
-
     // check popover is hidden
     assert.isFalse(popover.classList.contains("in"), "popover is now hidden");
   });

--- a/viewer/test/test-popovers-hiding.js
+++ b/viewer/test/test-popovers-hiding.js
@@ -1,28 +1,18 @@
-/* global addHeadingAnchors:false sinon:false */
+/* global addHeadingAnchors:false */
 
 var assert = chai.assert;
 
 describe("popover timing", function () {
-  var INTERACTION_TIMEOUT = 1000;
-  var clock;
-
   before(function () {
     this.testArea = document.getElementById("test-popovers-timing");
     addHeadingAnchors.init("#test-popovers-timing", "#test-popovers-timing .popovers");
-    this.clipboardAnchors = this.testArea.querySelectorAll("a[data-clipboard-text]");
-  });
-
-  beforeEach(function () {
-    clock = sinon.useFakeTimers();
-  });
-
-  afterEach(function () {
-  //  clock.restore();
+    this.firstClipboardAnchor = this.testArea.querySelector("a[data-clipboard-text]");
+    this.unrelatedHeading = this.testArea.querySelector("h2");
   });
 
   it("displays the popover, which then fades when the input is blurred", function () {
-    var firstAnchor = this.clipboardAnchors[0];
-    var input;
+    var firstAnchor = this.firstClipboardAnchor;
+    var unrelatedHeading = this.unrelatedHeading;
     var popover;
 
     firstAnchor.click();
@@ -32,21 +22,12 @@ describe("popover timing", function () {
 
     popover = this.testArea.querySelector(".popovers .popover");
 
-    // click into the text area
-    input = popover.querySelector("input");
-    input.focus();
-
-    // wait more than the timeout
-    clock.tick(INTERACTION_TIMEOUT);
-
     // check the popover is still visible
     assert.isTrue(popover.classList.contains("in"), "popover is not hidden");
 
-    // focus out of the popover
-    input.blur();
+    // click something else
 
-    // wait for timeout
-    clock.tick(INTERACTION_TIMEOUT);
+    unrelatedHeading.click();
 
     // check popover is hidden
     assert.isFalse(popover.classList.contains("in"), "popover is not hidden");

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -43,7 +43,7 @@
       <h6>No-id Heading 6</h6>
       <div class="popovers"></div>
   </div>
-  <div id="test-popovers-timing">
+  <div id="test-popovers-hiding">
       <h1 id='h1'>Heading 1</h1>
       <h2 id='h2'>Heading 2</h2>
       <h3 id='h3'>Heading 3</h3>

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -80,7 +80,7 @@
   <script src='add-heading-anchors.js'></script>
 
   <!--the actual test suite-->
-  <script src='test/test-popovers-timing.js'></script>
+  <script src='test/test-popovers-hiding.js'></script>
   <script src='test/test-add-heading-anchors.js'></script>
   <script src='test/test-popovers.js'></script>
 


### PR DESCRIPTION
No more double timers (css animation + timeout), no more managing to not actually fire the blur event, etc.  