### PR TITLE
Fix #24 - implement success tooltip

### DIFF
--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -3,6 +3,7 @@
 /*eslint-disable no-unused-vars*/
 var addHeadingAnchors = {
   /*eslint-enable no-unused-vars*/
+  TOOLTIP_TTL: 500,
 
   init: function (selector, popoverContainer) {
     this.popoverContainer = popoverContainer || "body";
@@ -63,13 +64,19 @@ var addHeadingAnchors = {
     });
 
     popover.on("shown", function () {
+      // warning:  due to a BS2 implementation detail, this handler ALSO fires
+      // when success tooltip is shown
+
       // Hide all other popovers
       // `this` is the anchor that triggered the shown event.
       $("a.headerLink").not(this).popover("hide");
       // the contents of popover are lazy-created, so this unfortunately needs to go here.
       var input = document.getElementById(inputId);
-      input.focus();
-      input.select();
+
+      if (input) {
+        input.focus();
+        input.select();
+      }
     });
   },
 
@@ -80,15 +87,10 @@ var addHeadingAnchors = {
       title: "Link copied!",
       trigger: "manual"
     });
-
-    tooltip.on("shown", function () {
-      setTimeout(function () {
-        $(anchor).tooltip('hide');
-      }, 500);
-    });
   },
 
   registerClipboardHandlers: function () {
+    var TOOLTIP_TTL = this.TOOLTIP_TTL;
     var clipboardErrorHandler = function (e) {
       $(e.trigger).popover("show");
     };
@@ -104,6 +106,9 @@ var addHeadingAnchors = {
         }
       }
       $(e.trigger).tooltip("show");
+      setTimeout(function () {
+        $(e.trigger).tooltip("hide");
+      }, TOOLTIP_TTL);
     };
 
     if (!this.handler) {

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -79,11 +79,15 @@ var addHeadingAnchors = {
 
     var ensureSuccessHandler = function (e) {
       var originalText = e.text;
-      var clipboardContent = window.clipboardData.getData("Text");
-      if (originalText !== clipboardContent) {
-        // actually, this was a failure because the content didn't actually make it to clipboardData
-        clipboardErrorHandler(e);
+      if (window.clipboardData) {
+        // IE only
+        var clipboardContent = window.clipboardData.getData("Text");
+        if (originalText !== clipboardContent) {
+          clipboardErrorHandler(e);
+          return;
+        }
       }
+      $(e.trigger).tooltip("show");
     };
 
     if (!this.handler) {

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -81,9 +81,7 @@ var addHeadingAnchors = {
   },
 
   createSuccessTooltip: function (anchor) {
-    var tooltip;
-
-    tooltip = $(anchor).tooltip({
+    $(anchor).tooltip({
       title: "Link copied!",
       trigger: "manual"
     });

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -23,6 +23,7 @@ var addHeadingAnchors = {
       var anchor = this.createAnchor(id);
       heading.appendChild(anchor);
       this.createPopover(anchor, id);
+      this.createSuccessTooltip(anchor);
     }.bind(this));
   },
 
@@ -69,6 +70,21 @@ var addHeadingAnchors = {
       var input = document.getElementById(inputId);
       input.focus();
       input.select();
+    });
+  },
+
+  createSuccessTooltip: function (anchor) {
+    var tooltip;
+
+    tooltip = $(anchor).tooltip({
+      title: "Link copied!",
+      trigger: "manual"
+    });
+
+    tooltip.on("shown", function () {
+      setTimeout(function () {
+        $(anchor).tooltip('hide');
+      }, 500);
     });
   },
 


### PR DESCRIPTION
When clipboard permissions actually work properly, show a tooltip saying "Link copied!"

Unfortunately this isn't easily testable:

- in Chrome/Firefox, this condition never occurs without user input
- in IE, you have to rapidly click allow permissions
