### PR TITLE
fix #22 anchor click jumping

### DIFF
--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -12,6 +12,7 @@ var addHeadingAnchors = {
       this.addAnchorsToHeadings();
       this.registerClipboardHandlers();
       this.registerDismissPopoverHandler();
+      this.registerJumpPreventer();
     }
   },
 
@@ -123,5 +124,21 @@ var addHeadingAnchors = {
         $("a.headerLink").popover("hide");
       }
     });
+  },
+
+  registerJumpPreventer: function () {
+    $("a.headerLink").click(function (e) {
+      var hash;
+      e.preventDefault();
+      hash = this.getAttribute("href");
+
+      if (window.history.pushState) {
+        window.history.pushState(null, null, hash);
+      } else {
+        // fallback for no history API - this will jump
+        window.location.hash = hash;
+      }
+    });
+
   }
 };

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -127,7 +127,7 @@ var addHeadingAnchors = {
   },
 
   registerJumpPreventer: function () {
-    $("a.headerLink").click(function (e) {
+    $(this.target).find("a.headerLink").click(function (e) {
       var hash = this.getAttribute("href");
       // this stops the default behaviour, which is to
       // set the location hash

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -128,14 +128,15 @@ var addHeadingAnchors = {
 
   registerJumpPreventer: function () {
     $("a.headerLink").click(function (e) {
-      var hash;
+      var hash = this.getAttribute("href");
+      // this stops the default behaviour, which is to
+      // set the location hash
       e.preventDefault();
-      hash = this.getAttribute("href");
 
       if (window.history.replaceState) {
         window.history.replaceState(null, null, hash);
       } else {
-        // fallback for no history API - this will jump
+        // fallback for no history API - this will still jump
         window.location.hash = hash;
       }
     });

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -132,8 +132,8 @@ var addHeadingAnchors = {
       e.preventDefault();
       hash = this.getAttribute("href");
 
-      if (window.history.pushState) {
-        window.history.pushState(null, null, hash);
+      if (window.history.replaceState) {
+        window.history.replaceState(null, null, hash);
       } else {
         // fallback for no history API - this will jump
         window.location.hash = hash;

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -72,6 +72,25 @@ describe("addHeadingAnchors", function () {
       });
     });
 
+    it("does not scroll when clicking on links", function () {
+      var clickAndAssertScrollUnchanged = function (anchor) {
+        var oldScrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+        var newScrollTop;
+
+        anchor.click();
+
+        newScrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+
+        assert.equal(
+          newScrollTop,
+          oldScrollTop,
+          "scroll top should match the stored value from before clicking"
+        );
+      };
+
+      Array.prototype.forEach.call(this.clipboardAnchors, clickAndAssertScrollUnchanged);
+    });
+
     it("fires the clipboardjs error callback when clicking on links", function (done) {
       // a quick alternative to spying
       var callCount = 0;

--- a/viewer/testrunner.html
+++ b/viewer/testrunner.html
@@ -28,12 +28,12 @@
     <div class="popovers"></div>
   </div>
   <div id="test-popovers">
-      <h1 id='h1'>Heading 1</h1>
-      <h2 id='h2'>Heading 2</h2>
-      <h3 id='h3'>Heading 3</h3>
-      <h4 id='h4'>Heading 4</h4>
-      <h5 id='h5'>Heading 5</h5>
-      <h6 id='h6'>Heading 6</h6>
+      <h1 id='popover-h1'>Heading 1</h1>
+      <h2 id='popover-h2'>Heading 2</h2>
+      <h3 id='popover-h3'>Heading 3</h3>
+      <h4 id='popover-h4'>Heading 4</h4>
+      <h5 id='popover-h5'>Heading 5</h5>
+      <h6 id='popover-h6'>Heading 6</h6>
 
       <h1>No-id Heading 1</h1>
       <h2>No-id Heading 2</h2>
@@ -44,12 +44,12 @@
       <div class="popovers"></div>
   </div>
   <div id="test-popovers-hiding">
-      <h1 id='h1'>Heading 1</h1>
-      <h2 id='h2'>Heading 2</h2>
-      <h3 id='h3'>Heading 3</h3>
-      <h4 id='h4'>Heading 4</h4>
-      <h5 id='h5'>Heading 5</h5>
-      <h6 id='h6'>Heading 6</h6>
+      <h1 id='hiding-h1'>Heading 1</h1>
+      <h2 id='hiding-h2'>Heading 2</h2>
+      <h3 id='hiding-h3'>Heading 3</h3>
+      <h4 id='hiding-h4'>Heading 4</h4>
+      <h5 id='hiding-h5'>Heading 5</h5>
+      <h6 id='hiding-h6'>Heading 6</h6>
 
       <h1>No-id Heading 1</h1>
       <h2>No-id Heading 2</h2>


### PR DESCRIPTION
Use the history API to manipulate the hash, because:

- having the default anchor behaviour causes a jump
- setting window.hash causes a jump 

Which is very annoying if you just want to grab a link to the current dialog.  