### PR TITLE
Don't create multiple anchors if init is called more than once

### DIFF
--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -37,7 +37,7 @@ var addHeadingAnchors = {
       class: "headerLink"
     };
 
-    icon.setAttribute("class", "icon-share");
+    icon.setAttribute("class", "icon-fixed-width icon-share");
 
     anchor.appendChild(icon);
 
@@ -83,7 +83,7 @@ var addHeadingAnchors = {
 
   createSuccessTooltip: function (anchor) {
     $(anchor).tooltip({
-      title: "Link copied!",
+      title: "Link Copied!",
       trigger: "manual"
     });
   },

--- a/viewer/add-heading-anchors.js
+++ b/viewer/add-heading-anchors.js
@@ -22,10 +22,13 @@ var addHeadingAnchors = {
 
     Array.prototype.forEach.call(headings, function (heading) {
       var id = heading.id;
-      var anchor = this.createAnchor(id);
-      heading.appendChild(anchor);
-      this.createPopover(anchor, id);
-      this.createSuccessTooltip(anchor);
+      // only add if no existing anchor
+      if (!heading.querySelector("a.headerLink")) {
+        var anchor = this.createAnchor(id);
+        heading.appendChild(anchor);
+        this.createPopover(anchor, id);
+        this.createSuccessTooltip(anchor);
+      }
     }.bind(this));
   },
 

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -67,10 +67,10 @@ describe("addHeadingAnchors", function () {
     });
 
     it("does not add more anchors if init is called more than once", function () {
-      var count = this.testContainer.querySelectorAll("a.headerLink").length;
+      var count = this.testcontainer.querySelectorAll("a.headerLink").length;
       var newCount;
       addHeadingAnchors.init("#testcontainer", "#testcontainer .popovers");
-      newCount = this.testContainer.querySelectorAll("a.headerLink").length;
+      newCount = this.testcontainer.querySelectorAll("a.headerLink").length;
       assert.equal(newCount, count);
     });
   });

--- a/viewer/test/test-add-heading-anchors.js
+++ b/viewer/test/test-add-heading-anchors.js
@@ -65,6 +65,14 @@ describe("addHeadingAnchors", function () {
 
       Array.prototype.forEach.call(this.headingsWithoutAnId, assertNoAnchorAdded);
     });
+
+    it("does not add more anchors if init is called more than once", function () {
+      var count = this.testContainer.querySelectorAll("a.headerLink").length;
+      var newCount;
+      addHeadingAnchors.init("#testcontainer", "#testcontainer .popovers");
+      newCount = this.testContainer.querySelectorAll("a.headerLink").length;
+      assert.equal(newCount, count);
+    });
   });
 
   describe("click handling", function () {


### PR DESCRIPTION
Some scenarios may cause init to be called more than once for convenience (for example, when on page document is swapped).  The plugin should be a bit more safe around handling these cases so we don't get duplicate anchors everywhere.  

This also contains fixes for #31 which were committed directly into the PolicyStat version of this plugin 