### PR TITLE
Handle cases where we're converting paragraphs with other tags to a heading

### DIFF
--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -112,8 +112,14 @@
       }
 
       function addIdIfNewHeading() {
-        var element = editor.getSelection().getStartElement();
-        if (isHeading(element) && !element.hasAttribute('id')) {
+        var path = editor.elementPath();
+
+        var evaluator = function(element) {
+          return isHeading(element) && !element.hasAttribute('id');
+        }
+
+        var element = path.contains(evaluator);
+        if (element) {
           addId(element);
         }
       }

--- a/tests/ids/add_ids.js
+++ b/tests/ids/add_ids.js
@@ -111,6 +111,33 @@
       wait();
     },
 
+    'test it will add an id when a paragraph with strong tag within is converted to heading': function() {
+      var bot = this.editorBot,
+        editor = this.editor,
+        paragraph,
+        heading,
+        style = new CKEDITOR.style({ element: 'h1' }),
+        resumeAfter = bender.tools.resumeAfter,
+        startHtml = '<p><strong>This paragraph will be converted^</strong></p>';
+
+      bot.setHtmlWithSelection(startHtml);
+      editor.execCommand('autoid');
+
+      paragraph = editor.editable().findOne('p');
+      assert.isFalse(paragraph.hasAttribute('id'));
+
+      resumeAfter(editor, 'idAdded', function() {
+        heading = editor.editable().findOne('h1');
+
+        assert.isTrue(heading.hasAttribute('id'));
+      });
+
+      // convert the paragraph to a heading
+      editor.applyStyle(style);
+
+      wait();
+    },
+
     'test it will retain the id if a heading is converted to a non-heading and back': function() {
       var bot = this.editorBot,
         editor = this.editor,


### PR DESCRIPTION
we were only checking the currently selected element, which fails if you have
`<p><strong>^asdf</strong></p>` for example

fixes #39 