### PR TITLE
Support telephone number in the URL insertion dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# IDE folder
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ node_js:
   - 10
 
 addons:
+  firefox: "latest"
   chrome: stable
 
 before_script:
-  - 'export CHROME_BIN=chromium-browser'
   - 'export DISPLAY=:99.0'
   - 'sleep 3'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: node_js
+services:
+  - xvfb
+
 node_js:
-  - "4.2.1"
+  - 10
+
+addons:
+  chrome: stable
+
 before_script:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - 'export CHROME_BIN=chromium-browser'
+  - 'export DISPLAY=:99.0'
+  - 'sleep 3'
 env:
   - TEST_DIR=.
   - TEST_DIR=viewer

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -243,7 +243,7 @@
 
       function modifiedLinkTypeChanged() {
         var dialog = this.getDialog(),
-          partIds = [ 'urlOptions', 'anchorOptions', 'emailOptions', 'headingOptions' ],
+          partIds = [ 'urlOptions', 'anchorOptions', 'emailOptions', 'telOptions', 'headingOptions' ],
           typeValue = this.getValue(),
           uploadTab = dialog.definition.getContents( 'upload' ),
           uploadInitiallyHidden = uploadTab && uploadTab.hidden;


### PR DESCRIPTION
In the March update of CKEditor, we brought Telephone number insertion in URL dialog.

In Autoid plugin we alter that dialog. So we have to properly support it.