### PR TITLE
Generate new ids for duplicated nested ids

### DIFF
--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -133,15 +133,18 @@
           pastedContentAsHtml = CKEDITOR.htmlParser.fragment.fromHtml(pastedContent),
           pastedElements = pastedContentAsHtml.children,
           writer = new CKEDITOR.htmlParser.basicWriter(),
-          i, element, id, originalHeading;
+          element, id, originalHeading;
 
-        for (i = 0; i < pastedElements.length; i++) {
-          element = pastedElements[i];
+        for (element of pastedElements) {
           if (element.type === CKEDITOR.NODE_ELEMENT) {
-            id = element.attributes.id;
-            originalHeading = checkForDuplicateId(id);
-            if (originalHeading) {
-              element = resolveDuplicateIds(element, originalHeading);
+            for (const filter of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']) {
+              for (var found of element.find(filter, true)){
+                id = found.attributes.id;
+                originalHeading = checkForDuplicateId(id);
+                if (originalHeading) {
+                  found = resolveDuplicateIds(found, originalHeading);
+                }
+              }
             }
           }
         }

--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -134,10 +134,10 @@
           found.push(node);
         }
         if (node.children === undefined){
-          return
+          return;
         }
         for(var child of node.children){
-          getChildrenRecursively(child, found)
+          getChildrenRecursively(child, found);
         }
       }
 

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -215,7 +215,90 @@
 
       // wait for initial id assignment for all headings to complete
       wait();
-    }
+    },
+
+    'test nested duplicated ids got resolved': function() {
+      var bot = this.editorBot,
+        editor = bot.editor,
+        heading,
+        headings,
+        resumeAfter = bender.tools.resumeAfter,
+        headingWithId = '<h1 id="12345">This is a heading</h1>',
+        headingWithTheSameId = '<div><h1 id="12345">This is nested heading with the same id</h1></div>';
+
+      bot.setHtmlWithSelection(headingWithId);
+
+      // hit enter key to prevent pasting text in same heading element
+      editor.editable().fire('keydown', new CKEDITOR.dom.event({
+        keyCode: 13,
+        ctrlKey: false,
+        shiftKey: false
+      }));
+
+      resumeAfter(editor, 'allIdsComplete', function() {
+        heading = editor.editable().findOne('h1');
+
+        // verify original heading still has same id
+        assert.areSame('12345', heading.getAttribute('id'));
+
+        editor.execCommand('paste', headingWithTheSameId);
+
+        headings = editor.editable().find('h1');
+
+        // verify pasted heading id is regenerated
+        assert.areNotSame('12345', headings.getItem(0).getAttribute('id'));
+
+        // verify original heading has the same id
+        assert.areSame('12345', headings.getItem(1).getAttribute('id'));
+      });
+
+      editor.execCommand('autoid');
+
+      // wait for initial id assignment for all headings to complete
+      wait();
+    },
+
+    'test nested unique id is not regenerated': function() {
+      var bot = this.editorBot,
+        editor = bot.editor,
+        heading,
+        headings,
+        resumeAfter = bender.tools.resumeAfter,
+        headingWithId = '<h1 id="12345">This is a heading</h1>',
+        headingWithTheSameId = '<div><h1 id="67890">This is nested heading with the same id</h1></div>';
+
+      bot.setHtmlWithSelection(headingWithId);
+
+      // hit enter key to prevent pasting text in same heading element
+      editor.editable().fire('keydown', new CKEDITOR.dom.event({
+        keyCode: 13,
+        ctrlKey: false,
+        shiftKey: false
+      }));
+
+      resumeAfter(editor, 'allIdsComplete', function() {
+        heading = editor.editable().findOne('h1');
+
+        // verify original heading still has same id
+        assert.areSame('12345', heading.getAttribute('id'));
+
+        editor.execCommand('paste', headingWithTheSameId);
+
+        headings = editor.editable().find('h1');
+
+        // verify pasted heading id is not regenerated
+        assert.areSame('67890', headings.getItem(0).getAttribute('id'));
+
+        // verify original heading has the same id
+        assert.areSame('12345', headings.getItem(1).getAttribute('id'));
+      });
+
+      editor.execCommand('autoid');
+
+      // wait for initial id assignment for all headings to complete
+      wait();
+    },
+
   });
 
 })();

--- a/tests/paste_events/paste_events.js
+++ b/tests/paste_events/paste_events.js
@@ -265,7 +265,7 @@
         headings,
         resumeAfter = bender.tools.resumeAfter,
         headingWithId = '<h1 id="12345">This is a heading</h1>',
-        headingWithTheSameId = '<div><h1 id="67890">This is nested heading with the same id</h1></div>';
+        headingWithTheDifferentId = '<div><h1 id="67890">this is a nested heading with a different id</h1></div>';
 
       bot.setHtmlWithSelection(headingWithId);
 
@@ -282,7 +282,7 @@
         // verify original heading still has same id
         assert.areSame('12345', heading.getAttribute('id'));
 
-        editor.execCommand('paste', headingWithTheSameId);
+        editor.execCommand('paste', headingWithTheDifferentId);
 
         headings = editor.editable().find('h1');
 


### PR DESCRIPTION
First PR for this trello card https://trello.com/c/uJMj6fBd/344-autoid-headings-the-paste-duplicate-heading-id-detection-does-not-correctly-handle-headings-that-are-not-root-level

Check nested headers and generate new ids for them.