### PR TITLE
Allow CKEditor build successfully again.

### DIFF
--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -136,8 +136,8 @@
         if (node.children === undefined){
           return;
         }
-        for(var child of node.children){
-          getChildrenRecursively(child, found);
+        for (var i=0; i < node.children.length; i++) {
+          getChildrenRecursively(node.children[i], found);
         }
       }
 


### PR DESCRIPTION
Make fix for re-generating duplicated ids, to allow compilation during CKEditor building stage

Followup for https://github.com/PolicyStat/ckeditor-plugin-autoid-headings/pull/42